### PR TITLE
don't show report abuse on current_user profile

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -145,14 +145,16 @@
       </div>
     </div>
     <%= render "articles/user_metadata", context: "profile" %>
-    <div class="profile-dropdown">
-      <button id="user-profile-dropdown">
-        <%= image_tag("three-dots.svg", class: "dropdown-icon", alt: "Toggle dropdown menu") %>
-      </button>
-      <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
-        <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
+    <% if current_user != @user %>
+      <div class="profile-dropdown">
+        <button id="user-profile-dropdown">
+          <%= image_tag("three-dots.svg", class: "dropdown-icon", alt: "Toggle dropdown menu") %>
+        </button>
+        <div id="user-profile-dropdownmenu" class="profile-dropdownmenu">
+          <a href="/report-abuse?url=https://dev.to/<%= @user.username %>">Report Abuse</a>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 <% end %>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
I think there is no reason to put the dropdown of `Report Abuse` on current user's profile page. Since the current user logged in will not want to report abuse of itself.

However, if current user is visiting any other profile, this dropdown should be shown.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
**Before:**
- Here is my profile when I'm logged in:
    ![image](https://user-images.githubusercontent.com/53116218/66914696-fc196880-f034-11e9-8786-c1ead33ffdf5.png)

**After:**
- Here is my profile when I'm logged in:
    ![image](https://user-images.githubusercontent.com/53116218/66914900-66320d80-f035-11e9-8b2e-979175b3ab2b.png)


- Here is someone's profile when I'm logged in:
    ![image](https://user-images.githubusercontent.com/53116218/66914850-4dc1f300-f035-11e9-8150-98db45440849.png)


## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l3q2Ty3RWark8VgIw/giphy.gif)
